### PR TITLE
Support specifying full Pixiv illustration URL as parameter

### DIFF
--- a/bin/dpi.ts
+++ b/bin/dpi.ts
@@ -7,7 +7,9 @@ import { run } from "../lib/download-pixiv-illustration";
 
 program
   .description("Downloads all pictures or videos for Pixiv illustrations")
-  .usage("ILLUSTRATION_ID [ILLUSTRATION_ID]...")
+  .usage(
+    "ILLUSTRATION_ID|ILLUSTRATION_URL [ILLUSTRATION_ID|ILLUSTRATION_URL]..."
+  )
   .option("-u, --username <username>", "Username of an existing Pixiv account.")
   .option("-p, --password <password>", "Password of an existing Pixiv account.")
   .option(
@@ -17,6 +19,18 @@ program
   .version(pkg.version, "-V, --version")
   .parse(process.argv);
 
-const [...illustrationIds] = program.args;
+run(
+  program.args.map((arg) => {
+    let illustrationId = arg;
 
-run(illustrationIds.map(id => Number.parseInt(id)), program.opts());
+    // Check if it is a URL
+    try {
+      const urlPathParts = new URL(arg).pathname.split("/");
+      illustrationId = urlPathParts[urlPathParts.length - 1];
+    } catch (err) {
+      // No URL so try to parse as illustration id
+    }
+    return Number.parseInt(illustrationId);
+  }),
+  program.opts()
+);


### PR DESCRIPTION
As I am too lazy to always extract the id from the URL, just add support for passing a complete URL again.